### PR TITLE
Minor Updates

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"
+            from: "600.0.0"
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,16 @@ import CompilerPluginSupport
 
 let package = Package(
     name: "Prototype",
-    platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v6), .macCatalyst(.v16)],
+    platforms: [.macOS(.v14), .iOS(.v16), .tvOS(.v16), .watchOS(.v6), .macCatalyst(.v16)],
     products: [
         .library(name: "Prototype", targets: ["Prototype", "PrototypeAPI"]),
         .library(name: "PrototypeUI", targets: ["PrototypeUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
+        .package(
+            url: "https://github.com/apple/swift-syntax.git",
+            from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"
+        ),
     ],
     targets: [
         .macro(

--- a/Sources/PrototypeMacros/PrototypeMacro.swift
+++ b/Sources/PrototypeMacros/PrototypeMacro.swift
@@ -248,7 +248,11 @@ extension PrototypeMacro {
 
         default:
             if spec.type.isNumeric {
-                result.append("TextField(\(key), value: \(binding), formatter: numberFormatter)")
+                if let formatExpression = spec.formatExpression {
+                    result.append("TextField(\(key), value: \(binding), format: \(formatExpression))")
+                } else {
+                    result.append("TextField(\(key), value: \(binding), formatter: numberFormatter)")
+                }
             } else {
                 result.append("\(spec.type.name)Form(model: \(binding))")
             }
@@ -302,7 +306,11 @@ extension PrototypeMacro {
 
         default:
             if spec.type.isNumeric {
-                result.append("TextField(\(key), value: \(binding), formatter: numberFormatter)")
+                if let formatExpression = spec.formatExpression {
+                    result.append("TextField(\(key), value: \(binding), format: \(formatExpression))")
+                } else {
+                    result.append("TextField(\(key), value: \(binding), formatter: numberFormatter)")
+                }
             } else {
                 result.append("\(spec.type.name)Form(model: \(binding))")
             }

--- a/Sources/PrototypeMacros/PrototypeMacro.swift
+++ b/Sources/PrototypeMacros/PrototypeMacro.swift
@@ -44,22 +44,26 @@ public struct PrototypeMacro: PeerMacro {
                 if isInSection {
                     body.append("}")
                 }
-                
+
+                let modelAttribute = spec.kind == .binding ? "@Binding" : "@ObservedObject"
+                let modelParameter = spec.kind == .binding ? "Binding<\(spec.name)>": "\(spec.name)"
+                let modelAssignment = spec.kind == .binding ? "self._model = model" : "self.model = model"
+
                 result.append(
                 """
                 \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)Form: View {
-                @Binding public var model: \(raw: spec.name)
+                \(raw: modelAttribute) public var model: \(raw: spec.name)
                 private let footer: AnyView?
                 private let numberFormatter: NumberFormatter
                 
-                public init(model: Binding<\(raw: spec.name)>, numberFormatter: NumberFormatter = .init()) {
-                    self._model = model
+                public init(model: \(raw: modelParameter), numberFormatter: NumberFormatter = .init()) {
+                    \(raw: modelAssignment)
                     self.footer = nil
                     self.numberFormatter = numberFormatter
                 }
                 
-                public init<Footer>(model: Binding<\(raw: spec.name)>, numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
-                    self._model = model
+                public init<Footer>(model: \(raw: modelParameter), numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                    \(raw: modelAssignment)
                     self.footer = AnyView(erasing: footer())
                     self.numberFormatter = numberFormatter
                 }

--- a/Sources/PrototypeMacros/PrototypeMacro.swift
+++ b/Sources/PrototypeMacros/PrototypeMacro.swift
@@ -331,12 +331,6 @@ extension PrototypeMacro {
             result.append("LabeledContent(\(labelKey)) {")
         }
         
-        let numericTypes = [
-            "Int8", "Int16", "Int32", "Int64", "Int", 
-            "UInt8", "UInt16", "UInt32", "UInt64", "UInt",
-            "Float16", "Float32", "Float64", "Float80", "Float", "Double"
-        ]
-        
         if spec.type.name == "Bool" {
             result.append(
             """
@@ -361,7 +355,7 @@ extension PrototypeMacro {
             } else {
                 result.append("LabeledContent(\(key), value: model.\(spec.name), format: .dateTime)")
             }
-        } else if numericTypes.contains(spec.type.name) {
+        } else if spec.type.isNumeric {
             if let formatExpression = spec.formatExpression {
                 result.append("LabeledContent(\(key), value: model.\(spec.name), format: \(formatExpression))")
             } else {

--- a/Sources/PrototypeMacros/PrototypeTypeSpec.swift
+++ b/Sources/PrototypeMacros/PrototypeTypeSpec.swift
@@ -28,7 +28,8 @@ extension PrototypeTypeSpec {
     private static let numericTypes: [String] = [
         "Int8", "Int16", "Int32", "Int64", "Int",
         "UInt8", "UInt16", "UInt32", "UInt64", "UInt",
-        "Float16", "Float32", "Float64", "Float80", "Float", "Double"
+        "Float16", "Float32", "Float64", "Float80", "Float", "Double",
+        "Decimal"
     ]
 
     public var isBool: Bool { name == "Bool" }

--- a/Tests/PrototypeTests/PrototypeTests.swift
+++ b/Tests/PrototypeTests/PrototypeTests.swift
@@ -12,6 +12,44 @@ let testMacros: [String: Macro.Type] = [
 #endif
 
 final class PrototypeTests: XCTestCase {
+    func testProtoptypeMacroSupportsDecimal() throws {
+#if canImport(PrototypeMacros)
+        assertMacroExpansion(
+            """
+            @Prototype(kinds: .view)
+            class MyClass {
+                @Format(using: .custom)
+                let decimalValue: Decimal
+            }
+            """,
+            expandedSource: """
+            class MyClass {
+                @Format(using: .custom)
+                let decimalValue: Decimal
+            }
+            
+            struct MyClassView: View {
+                public let model: MyClass
+            
+                public init(model: MyClass) {
+                    self.model = model
+                }
+            
+                public var body: some View {
+                    LabeledContent("MyClassView.decimalValue.label") {
+                        LabeledContent("MyClassView.decimalValue", value: model.decimalValue, format: .custom)
+                    }
+                }
+            }
+            """,
+            diagnostics: [],
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
     func testPrototypeMacroErrorUnsupportedPeerDeclarationOnEnum() throws {
         #if canImport(PrototypeMacros)
         assertMacroExpansion(

--- a/Tests/PrototypeTests/PrototypeTests.swift
+++ b/Tests/PrototypeTests/PrototypeTests.swift
@@ -316,4 +316,108 @@ final class PrototypeTests: XCTestCase {
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
+
+    func testProtoytypeFormWithObservableObject() {
+#if canImport(PrototypeMacros)
+        assertMacroExpansion(
+            """
+            @Prototype(kinds: .form)
+            class Sample: ObservableObject {
+                var value: Int
+            }
+            """,
+            expandedSource: """
+            class Sample: ObservableObject {
+                var value: Int
+            }
+            
+            struct SampleForm: View {
+                @ObservedObject public var model: Sample
+                private let footer: AnyView?
+                private let numberFormatter: NumberFormatter
+            
+                public init(model: Sample, numberFormatter: NumberFormatter = .init()) {
+                    self.model = model
+                    self.footer = nil
+                    self.numberFormatter = numberFormatter
+                }
+            
+                public init<Footer>(model: Sample, numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                    self.model = model
+                    self.footer = AnyView(erasing: footer())
+                    self.numberFormatter = numberFormatter
+                }
+            
+                public var body: some View {
+                    Form {
+                        LabeledContent("SampleForm.value.label") {
+                            TextField("SampleForm.value", value: $model.value, formatter: numberFormatter)
+                        }
+            
+                        if let footer {
+                            footer
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [],
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
+    func testProtoytypeFormWithClass() {
+#if canImport(PrototypeMacros)
+        assertMacroExpansion(
+            """
+            @Prototype(kinds: .form)
+            class Sample {
+                var value: Int
+            }
+            """,
+            expandedSource: """
+            class Sample {
+                var value: Int
+            }
+            
+            struct SampleForm: View {
+                @Binding public var model: Sample
+                private let footer: AnyView?
+                private let numberFormatter: NumberFormatter
+            
+                public init(model: Binding<Sample>, numberFormatter: NumberFormatter = .init()) {
+                    self._model = model
+                    self.footer = nil
+                    self.numberFormatter = numberFormatter
+                }
+            
+                public init<Footer>(model: Binding<Sample>, numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                    self._model = model
+                    self.footer = AnyView(erasing: footer())
+                    self.numberFormatter = numberFormatter
+                }
+            
+                public var body: some View {
+                    Form {
+                        LabeledContent("SampleForm.value.label") {
+                            TextField("SampleForm.value", value: $model.value, formatter: numberFormatter)
+                        }
+            
+                        if let footer {
+                            footer
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [],
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
 }


### PR DESCRIPTION
* Updated minimum macOS version to 14  to compile on Xcode 16.2.
* recognize `Decimal` as a "numeric" type.
* apply `@Format` to `.form` and `.settings` as well as `.view`
* update to SwiftSyntax 600, currently released version
* support `@ObservedObject`/`ObservableObject` as well as `Binding`
