### PR TITLE
Add support for generic form types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     }
   ],

--- a/Sources/PrototypeMacros/PrototypeMacro.swift
+++ b/Sources/PrototypeMacros/PrototypeMacro.swift
@@ -70,13 +70,13 @@ extension PrototypeMacro {
         }
 
         let modelAttribute = spec.kind == .binding ? "@Binding" : "@ObservedObject"
-        let modelParameter = spec.kind == .binding ? "Binding<\(spec.name)>": "\(spec.name)"
+        let modelParameter = spec.kind == .binding ? "Binding<\(spec.name)\(spec.genericParameters)>": "\(spec.name)"
         let modelAssignment = spec.kind == .binding ? "self._model = model" : "self.model = model"
 
         return
             """
-            \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)Form: View {
-            \(raw: modelAttribute) public var model: \(raw: spec.name)
+            \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)Form\(raw: spec.genericParametersClause): View \(raw: spec.genericWhereClause){
+            \(raw: modelAttribute) public var model: \(raw: spec.name)\(raw: spec.genericParameters)
             private let footer: AnyView?
             private let numberFormatter: NumberFormatter
             
@@ -211,7 +211,7 @@ extension PrototypeMacro {
 
         return
             """
-            \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)SettingsView: View {
+            \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)SettingsView\(raw: spec.genericParametersClause): View \(raw: spec.genericWhereClause){
             \(raw: properties.joined(separator: "\n"))
             private let footer: AnyView?
             private let numberFormatter: NumberFormatter
@@ -329,10 +329,10 @@ extension PrototypeMacro {
 
         return
                 """
-                \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)View: View {
-                public let model: \(raw: spec.name)
+                \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)View\(raw: spec.genericParametersClause): View \(raw: spec.genericWhereClause){
+                public let model: \(raw: spec.name)\(raw: spec.genericParameters)
                 
-                public init(model: \(raw: spec.name)) {
+                public init(model: \(raw: spec.name)\(raw: spec.genericParameters)) {
                     self.model = model
                 }
                 

--- a/Sources/PrototypeMacros/PrototypeMacro.swift
+++ b/Sources/PrototypeMacros/PrototypeMacro.swift
@@ -14,199 +14,19 @@ public struct PrototypeMacro: PeerMacro {
         
         let arguments = try PrototypeMacroArguments(from: node)
         let spec = try PrototypeSpec(parsing: declaration)
-        var result: [DeclSyntax] = []
 
-        try arguments.kinds.forEach { kind in
+        return try arguments.kinds.map { kind in
             switch kind {
             case .form:
-                let members = spec.members.filter { member in member.attributes.contains(.visible) }
-                var isInSection = false
-                var body: [String] = []
-                
-                try members.forEach { member in
-                    if member.attributes.contains(.section) {
-                        if isInSection {
-                            body.append("}")
-                        }
-                        
-                        isInSection = true
-                        
-                        if let sectionTitle = member.sectionTitle {
-                            body.append("Section(header: Text(\"\(spec.name)Form.\(sectionTitle)\")) {")
-                        } else {
-                            body.append("Section {")
-                        }
-                    }
-                    
-                    body.append(try buildMemberSpecFormSyntax(arguments: arguments, keyPrefix: "\(spec.name)Form", spec: member))
-                }
-                
-                if isInSection {
-                    body.append("}")
-                }
+                try buildFormSyntax(spec: spec, arguments: arguments)
 
-                let modelAttribute = spec.kind == .binding ? "@Binding" : "@ObservedObject"
-                let modelParameter = spec.kind == .binding ? "Binding<\(spec.name)>": "\(spec.name)"
-                let modelAssignment = spec.kind == .binding ? "self._model = model" : "self.model = model"
-
-                result.append(
-                """
-                \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)Form: View {
-                \(raw: modelAttribute) public var model: \(raw: spec.name)
-                private let footer: AnyView?
-                private let numberFormatter: NumberFormatter
-                
-                public init(model: \(raw: modelParameter), numberFormatter: NumberFormatter = .init()) {
-                    \(raw: modelAssignment)
-                    self.footer = nil
-                    self.numberFormatter = numberFormatter
-                }
-                
-                public init<Footer>(model: \(raw: modelParameter), numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
-                    \(raw: modelAssignment)
-                    self.footer = AnyView(erasing: footer())
-                    self.numberFormatter = numberFormatter
-                }
-
-                public var body: some View {
-                    Form {
-                        \(raw: body.joined(separator: "\n"))
-                
-                        if let footer {
-                            footer
-                        }
-                    }
-                }
-                }
-                """
-                )
-                
             case .settings:
-                let members = spec.members.filter { member in member.attributes.contains(.visible) }
-                var isInSection = false
-                var properties: [String] = []
-                var body: [String] = []
-                
-                members.forEach { member in
-                    let key = "\(spec.name).\(member.name)"
-                    let defaultInitializer = member.type.isOptional ? "" : "= .init()"
-                    let initializer = member.initializer?.description ?? defaultInitializer
-                    let tail = member.type.isOptional ? "?" : ""
-                    properties.append("@AppStorage(\"\(key)\") private var \(member.name): \(member.type.name)\(tail) \(initializer)")
-                }
-                
-                members.forEach { member in
-                    guard member.type.isOptional else { return }
+                try buildSettingsSyntax(spec: spec, arguments: arguments)
 
-                    properties.append(
-                    """
-                    private var \(member.name)Binding: Binding<\(member.type.name)> {
-                        Binding(
-                            get: { \(member.name) ?? \(member.type.defaultValue) },
-                            set: { \(member.name) = $0 }
-                        )
-                    }
-                    """
-                    )
-                }
-                
-                try members.forEach { member in
-                    if member.attributes.contains(.section) {
-                        if isInSection {
-                            body.append("}")
-                        }
-                        
-                        isInSection = true
-                        
-                        if let sectionTitle = member.sectionTitle {
-                            body.append("Section(header: Text(\"\(spec.name)Form.\(sectionTitle)\")) {")
-                        } else {
-                            body.append("Section {")
-                        }
-                    }
-                    
-                    body.append(try buildMemberSpecSettingsSyntax(arguments: arguments, keyPrefix: "\(spec.name)SettingsView", spec: member))
-                }
-                
-                if isInSection {
-                    body.append("}")
-                }
-                
-                result.append(
-                """
-                \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)SettingsView: View {
-                \(raw: properties.joined(separator: "\n"))
-                private let footer: AnyView?
-                private let numberFormatter: NumberFormatter
-                
-                public init<Footer>(numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
-                    self.footer = AnyView(erasing: footer())
-                    self.numberFormatter = numberFormatter
-                }
-
-                public var body: some View {
-                    Form {
-                        \(raw: body.joined(separator: "\n"))
-                
-                        if let footer {
-                            footer
-                        }
-                    }
-                }
-                }
-                """
-                )
-                
             case .view:
-                let members = spec.members.filter { member in member.attributes.contains(.visible) }
-                var isInSection = false
-                var body: [String] = []
-                
-                try members.forEach { member in
-                    if member.attributes.contains(.section) {
-                        if isInSection {
-                            body.append("}")
-                        }
-                        
-                        isInSection = true
-                        
-                        if let sectionTitle = member.sectionTitle {
-                            body.append("GroupBox(\"\(spec.name)View.\(sectionTitle)\") {")
-                        } else {
-                            body.append("GroupBox {")
-                        }
-                    }
-                    
-                    body.append(try buildMemberSpecViewSyntax(arguments: arguments, keyPrefix: "\(spec.name)View", spec: member))
-                }
-                
-                if isInSection {
-                    body.append("}")
-                }
-                
-                if body.isEmpty {
-                    body.append("EmptyView()")
-                }
-                
-                result.append(
-                """
-                \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)View: View {
-                public let model: \(raw: spec.name)
-                
-                public init(model: \(raw: spec.name)) {
-                    self.model = model
-                }
-
-                public var body: some View {
-                    \(raw: body.joined(separator: "\n"))
-                }
-                }
-                """
-                )
+                try buildViewSyntax(spec: spec, arguments: arguments)
             }
         }
-        
-        return result
     }
 }
 
@@ -219,7 +39,72 @@ extension PrototypeMacro {
     }
 }
 
+// Form building support
+
 extension PrototypeMacro {
+    private static func buildFormSyntax(spec: PrototypeSpec, arguments: PrototypeMacroArguments) throws -> DeclSyntax {
+        let members = spec.members.filter { member in member.attributes.contains(.visible) }
+        var isInSection = false
+        var body: [String] = []
+
+        try members.forEach { member in
+            if member.attributes.contains(.section) {
+                if isInSection {
+                    body.append("}")
+                }
+
+                isInSection = true
+
+                if let sectionTitle = member.sectionTitle {
+                    body.append("Section(header: Text(\"\(spec.name)Form.\(sectionTitle)\")) {")
+                } else {
+                    body.append("Section {")
+                }
+            }
+
+            body.append(try buildMemberSpecFormSyntax(arguments: arguments, keyPrefix: "\(spec.name)Form", spec: member))
+        }
+
+        if isInSection {
+            body.append("}")
+        }
+
+        let modelAttribute = spec.kind == .binding ? "@Binding" : "@ObservedObject"
+        let modelParameter = spec.kind == .binding ? "Binding<\(spec.name)>": "\(spec.name)"
+        let modelAssignment = spec.kind == .binding ? "self._model = model" : "self.model = model"
+
+        return
+            """
+            \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)Form: View {
+            \(raw: modelAttribute) public var model: \(raw: spec.name)
+            private let footer: AnyView?
+            private let numberFormatter: NumberFormatter
+            
+            public init(model: \(raw: modelParameter), numberFormatter: NumberFormatter = .init()) {
+                \(raw: modelAssignment)
+                self.footer = nil
+                self.numberFormatter = numberFormatter
+            }
+            
+            public init<Footer>(model: \(raw: modelParameter), numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                \(raw: modelAssignment)
+                self.footer = AnyView(erasing: footer())
+                self.numberFormatter = numberFormatter
+            }
+            
+            public var body: some View {
+                Form {
+                    \(raw: body.joined(separator: "\n"))
+            
+                    if let footer {
+                        footer
+                    }
+                }
+            }
+            }
+            """
+    }
+
     private static func buildMemberSpecFormSyntax(
         arguments: PrototypeMacroArguments,
         keyPrefix: String,
@@ -235,7 +120,7 @@ extension PrototypeMacro {
         if arguments.style == .labeled {
             result.append("LabeledContent(\(labelKey)) {")
         }
-        
+
         switch spec.type.name {
         case "Bool":
             result.append("Toggle(\(key), isOn: \(binding))")
@@ -246,7 +131,7 @@ extension PrototypeMacro {
             } else {
                 result.append("TextField(\(key), text: \(binding))")
             }
-            
+
         case "Date":
             result.append("DatePicker(\(key), selection: \(binding))")
 
@@ -261,14 +146,94 @@ extension PrototypeMacro {
                 result.append("\(spec.type.name)Form(model: \(binding))")
             }
         }
-        
+
         if arguments.style == .labeled {
             result.append("}")
         }
-        
+
         return result.joined(separator: "\n")
     }
-    
+}
+
+// Settings building support
+
+extension PrototypeMacro {
+    private static func buildSettingsSyntax(spec: PrototypeSpec, arguments: PrototypeMacroArguments) throws -> DeclSyntax {
+        let members = spec.members.filter { member in member.attributes.contains(.visible) }
+        var isInSection = false
+        var properties: [String] = []
+        var body: [String] = []
+
+        members.forEach { member in
+            let key = "\(spec.name).\(member.name)"
+            let defaultInitializer = member.type.isOptional ? "" : "= .init()"
+            let initializer = member.initializer?.description ?? defaultInitializer
+            let tail = member.type.isOptional ? "?" : ""
+            properties.append("@AppStorage(\"\(key)\") private var \(member.name): \(member.type.name)\(tail) \(initializer)")
+        }
+
+        members.forEach { member in
+            guard member.type.isOptional else { return }
+
+            properties.append(
+                    """
+                    private var \(member.name)Binding: Binding<\(member.type.name)> {
+                        Binding(
+                            get: { \(member.name) ?? \(member.type.defaultValue) },
+                            set: { \(member.name) = $0 }
+                        )
+                    }
+                    """
+            )
+        }
+
+        try members.forEach { member in
+            if member.attributes.contains(.section) {
+                if isInSection {
+                    body.append("}")
+                }
+
+                isInSection = true
+
+                if let sectionTitle = member.sectionTitle {
+                    body.append("Section(header: Text(\"\(spec.name)Form.\(sectionTitle)\")) {")
+                } else {
+                    body.append("Section {")
+                }
+            }
+
+            body.append(try buildMemberSpecSettingsSyntax(arguments: arguments, keyPrefix: "\(spec.name)SettingsView", spec: member))
+        }
+
+        if isInSection {
+            body.append("}")
+        }
+
+        return
+            """
+            \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)SettingsView: View {
+            \(raw: properties.joined(separator: "\n"))
+            private let footer: AnyView?
+            private let numberFormatter: NumberFormatter
+            
+            public init<Footer>(numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                self.footer = AnyView(erasing: footer())
+                self.numberFormatter = numberFormatter
+            }
+            
+            public var body: some View {
+                Form {
+                    \(raw: body.joined(separator: "\n"))
+            
+                    if let footer {
+                        footer
+                    }
+                }
+            }
+            }
+            """
+    }
+
     private static func buildMemberSpecSettingsSyntax(
         arguments: PrototypeMacroArguments,
         keyPrefix: String,
@@ -281,7 +246,7 @@ extension PrototypeMacro {
         let key = "\"\(keyPrefix).\(spec.name)\""
         let labelKey = "\"\(keyPrefix).\(spec.name).label\""
         var binding = spec.attributes.contains(.modifiable) ? "$\(spec.name)" : ".constant(\(spec.name))"
-        
+
         if spec.type.isOptional {
             if spec.attributes.contains(.modifiable) {
                 binding = "\(spec.name)Binding"
@@ -293,7 +258,7 @@ extension PrototypeMacro {
         if arguments.style == .labeled {
             result.append("LabeledContent(\(labelKey)) {")
         }
-        
+
         switch spec.type.name {
         case "Bool":
             result.append("Toggle(\(key), isOn: \(binding))")
@@ -304,7 +269,7 @@ extension PrototypeMacro {
             } else {
                 result.append("TextField(\(key), text: \(binding))")
             }
-            
+
         case "Date":
             result.append("DatePicker(\(key), selection: \(binding))")
 
@@ -319,14 +284,65 @@ extension PrototypeMacro {
                 result.append("\(spec.type.name)Form(model: \(binding))")
             }
         }
-        
+
         if arguments.style == .labeled {
             result.append("}")
         }
-        
+
         return result.joined(separator: "\n")
     }
-    
+}
+
+// View building support
+
+extension PrototypeMacro {
+    private static func buildViewSyntax(spec: PrototypeSpec, arguments: PrototypeMacroArguments) throws -> DeclSyntax {
+        let members = spec.members.filter { member in member.attributes.contains(.visible) }
+        var isInSection = false
+        var body: [String] = []
+
+        try members.forEach { member in
+            if member.attributes.contains(.section) {
+                if isInSection {
+                    body.append("}")
+                }
+
+                isInSection = true
+
+                if let sectionTitle = member.sectionTitle {
+                    body.append("GroupBox(\"\(spec.name)View.\(sectionTitle)\") {")
+                } else {
+                    body.append("GroupBox {")
+                }
+            }
+
+            body.append(try buildMemberSpecViewSyntax(arguments: arguments, keyPrefix: "\(spec.name)View", spec: member))
+        }
+
+        if isInSection {
+            body.append("}")
+        }
+
+        if body.isEmpty {
+            body.append("EmptyView()")
+        }
+
+        return
+                """
+                \(raw: spec.accessLevelModifiers.structDeclAccessLevelModifiers) struct \(raw: spec.name)View: View {
+                public let model: \(raw: spec.name)
+                
+                public init(model: \(raw: spec.name)) {
+                    self.model = model
+                }
+                
+                public var body: some View {
+                    \(raw: body.joined(separator: "\n"))
+                }
+                }
+                """
+    }
+
     private static func buildMemberSpecViewSyntax(
         arguments: PrototypeMacroArguments,
         keyPrefix: String,

--- a/Sources/PrototypeMacros/PrototypeSpec.swift
+++ b/Sources/PrototypeMacros/PrototypeSpec.swift
@@ -12,17 +12,26 @@ public struct PrototypeSpec {
     public let name: String
     public let members: [PrototypeMemberSpec]
     public let kind: Kind
+    public let genericParametersClause: String
+    public let genericParameters: String
+    public let genericWhereClause: String
 
     public init(
         accessLevelModifiers: AccessLevelModifiers,
         name: String,
         members: [PrototypeMemberSpec],
-        kind: Kind = .binding
+        kind: Kind = .binding,
+        genericParametersClause: String,
+        genericParameters: String,
+        genericWhereClause: String
     ) {
         self.accessLevelModifiers = accessLevelModifiers
         self.name = name
         self.members = members
         self.kind = kind
+        self.genericParametersClause = genericParametersClause
+        self.genericParameters = genericParameters
+        self.genericWhereClause = genericWhereClause
     }
 
     public init(parsing declaration: some DeclSyntaxProtocol) throws {
@@ -54,7 +63,10 @@ public struct PrototypeSpec {
             accessLevelModifiers: declaration.accessLevelModifiers,
             name: declaration.name.trimmed.text,
             members: members,
-            kind: kind
+            kind: kind,
+            genericParametersClause: declaration.genericParameterClause?.trimmedDescription ?? "",
+            genericParameters: declaration.genericParameterClause?.names ?? "",
+            genericWhereClause: declaration.genericWhereClause?.trimmedDescription ?? ""
         )
     }
     
@@ -69,6 +81,22 @@ public struct PrototypeSpec {
             return nil
         }.reduce([], +)
         
-        self.init(accessLevelModifiers: declaration.accessLevelModifiers, name: declaration.name.trimmed.text, members: members)
+        self.init(
+            accessLevelModifiers: declaration.accessLevelModifiers,
+            name: declaration.name.trimmed.text,
+            members: members,
+            genericParametersClause: declaration.genericParameterClause?.trimmedDescription ?? "",
+            genericParameters: declaration.genericParameterClause?.names ?? "",
+            genericWhereClause: declaration.genericWhereClause?.trimmedDescription ?? ""
+        )
+    }
+}
+
+extension GenericParameterClauseSyntax {
+    var names: String {
+        return "<" + parameters.map {
+            $0.name.trimmedDescription
+        }
+        .joined(separator: ", ") + ">"
     }
 }

--- a/Tests/PrototypeTests/PrototypeTests.swift
+++ b/Tests/PrototypeTests/PrototypeTests.swift
@@ -51,7 +51,7 @@ final class PrototypeTests: XCTestCase {
     }
 
     func testPrototypeMacroErrorUnsupportedPeerDeclarationOnEnum() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             @Prototype(kinds: .view)
@@ -69,13 +69,13 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroErrorUnsupportedPeerDeclarationOnVariable() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             @Prototype(kinds: .view)
@@ -93,13 +93,13 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroErrorInvalidPrototypeKindArgument() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             @Prototype(kinds: .unknown)
@@ -117,13 +117,13 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
 
     func testPrototypeMacroErrorMissingPrototypeKindArgument() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             @Prototype()
@@ -141,13 +141,13 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroErrorDuplicatePrototypeKindArgument() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             @Prototype(kinds: .view, .form, .form, .view)
@@ -165,17 +165,17 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroErrorMissingMemberPatternTypeAnnotation() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             import SwiftUI
-
+            
             @Prototype(kinds: .form)
             struct MyStruct {
                 @Environment(\\.accessibilityEnabled) var accessibilityEnabled
@@ -196,17 +196,17 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroErrorUnsupportedMemberPatternBinding() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             import SwiftUI
-
+            
             @Prototype(kinds: .form)
             class MyClass {
                 var callable: () -> Void
@@ -227,17 +227,17 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroErrorUnsupportedPatternBinding() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             import SwiftUI
-
+            
             @Prototype(kinds: .form)
             class MyClass {
                 var (x, y): (Int, Int)
@@ -258,17 +258,17 @@ final class PrototypeTests: XCTestCase {
             ],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
-    
+
     func testPrototypeMacroWithSettingsKind() throws {
-        #if canImport(PrototypeMacros)
+#if canImport(PrototypeMacros)
         assertMacroExpansion(
             """
             import SwiftUI
-
+            
             @Prototype(style: .inline, kinds: .settings)
             struct General {
                 var showPreview: Bool = false
@@ -283,25 +283,25 @@ final class PrototypeTests: XCTestCase {
                 var text: String = "Hello World!"
                 var fontSize: Double = 12.0
             }
-
+            
             struct GeneralSettingsView: View {
                 @AppStorage("General.showPreview") private var showPreview: Bool = false
                 @AppStorage("General.text") private var text: String = "Hello World!"
                 @AppStorage("General.fontSize") private var fontSize: Double = 12.0
                 private let footer: AnyView?
                 private let numberFormatter: NumberFormatter
-
+            
                 public init<Footer>(numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
                     self.footer = AnyView(erasing: footer())
                     self.numberFormatter = numberFormatter
                 }
-
+            
                 public var body: some View {
                     Form {
                         Toggle("GeneralSettingsView.showPreview", isOn: $showPreview)
                         TextField("GeneralSettingsView.text", text: $text)
                         TextField("GeneralSettingsView.fontSize", value: $fontSize, formatter: numberFormatter)
-
+            
                         if let footer {
                             footer
                         }
@@ -312,9 +312,9 @@ final class PrototypeTests: XCTestCase {
             diagnostics: [],
             macros: testMacros
         )
-        #else
+#else
         throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+#endif
     }
 
     func testProtoytypeFormWithObservableObject() {
@@ -406,6 +406,127 @@ final class PrototypeTests: XCTestCase {
                             TextField("SampleForm.value", value: $model.value, formatter: numberFormatter)
                         }
             
+                        if let footer {
+                            footer
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [],
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
+    func testViewHandlesGenericStruct() throws {
+#if canImport(PrototypeMacros)
+        assertMacroExpansion(
+            """
+            @Prototype(kinds: .view)
+            struct Sample<Data> where Data: Match {
+            }
+            """,
+            expandedSource: """
+            struct Sample<Data> where Data: Match {
+            }
+            
+            struct SampleView<Data>: View where Data: Match {
+                public let model: Sample<Data>
+            
+                public init(model: Sample<Data>) {
+                    self.model = model
+                }
+            
+                public var body: some View {
+                    EmptyView()
+                }
+            }
+            """,
+            diagnostics: [],
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
+    func testFormHandlesGenericStruct() throws {
+#if canImport(PrototypeMacros)
+        assertMacroExpansion(
+            """
+            @Prototype(kinds: .form)
+            struct Sample<Data> where Data: Match {
+            }
+            """,
+            expandedSource: """
+            struct Sample<Data> where Data: Match {
+            }
+            
+            struct SampleForm<Data>: View where Data: Match {
+                @Binding public var model: Sample<Data>
+                private let footer: AnyView?
+                private let numberFormatter: NumberFormatter
+            
+                public init(model: Binding<Sample<Data>>, numberFormatter: NumberFormatter = .init()) {
+                    self._model = model
+                    self.footer = nil
+                    self.numberFormatter = numberFormatter
+                }
+            
+                public init<Footer>(model: Binding<Sample<Data>>, numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                    self._model = model
+                    self.footer = AnyView(erasing: footer())
+                    self.numberFormatter = numberFormatter
+                }
+            
+                public var body: some View {
+                    Form {
+            
+            
+                        if let footer {
+                            footer
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [],
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
+    func testSettingsHandlesGenericStruct() throws {
+#if canImport(PrototypeMacros)
+        assertMacroExpansion(
+            """
+            @Prototype(kinds: .settings)
+            struct Sample<Data> where Data: Match {
+            }
+            """,
+            expandedSource: """
+            struct Sample<Data> where Data: Match {
+            }
+            
+            struct SampleSettingsView<Data>: View where Data: Match {
+
+                private let footer: AnyView?
+                private let numberFormatter: NumberFormatter
+
+                public init<Footer>(numberFormatter: NumberFormatter = .init(), @ViewBuilder footer: () -> Footer) where Footer: View {
+                    self.footer = AnyView(erasing: footer())
+                    self.numberFormatter = numberFormatter
+                }
+
+                public var body: some View {
+                    Form {
+
+
                         if let footer {
                             footer
                         }


### PR DESCRIPTION
Addresses https://github.com/mrylmz/Prototype/issues/3 by adding support for generic form types to `.form`, `.view`, and `.settings`.